### PR TITLE
Fix horizontal/vertical spacing props

### DIFF
--- a/ui-framework/components/containers/MainView.tsx
+++ b/ui-framework/components/containers/MainView.tsx
@@ -56,11 +56,15 @@ const MainView: React.FC<BaseContainerProps> = ({
   mb,
   ml,
   mr,
+  mx,
+  my,
   padding: p,
   pt = "safeArea",
   pb,
   pl,
   pr,
+  px,
+  py,
 
   // Custom
   style,
@@ -71,11 +75,15 @@ const MainView: React.FC<BaseContainerProps> = ({
     mb,
     ml,
     mr,
+    mx,
+    my,
     padding: p,
     pt,
     pb,
     pl,
     pr,
+    px,
+    py,
   });
 
   const mainStyles = {

--- a/ui-framework/components/containers/RowView.tsx
+++ b/ui-framework/components/containers/RowView.tsx
@@ -18,14 +18,33 @@ const RowView: React.FC<BaseContainerProps> = ({
   pb,
   pl,
   pr,
+  px,
+  py,
   margin,
   mt,
   mb,
   ml,
   mr,
+  mx,
+  my,
   style,
 }) => {
-  const spacing = getSpacingStyles({ padding, pt, pb, pl, pr, margin, mt, mb, ml, mr });
+  const spacing = getSpacingStyles({
+    padding,
+    pt,
+    pb,
+    pl,
+    pr,
+    px,
+    py,
+    margin,
+    mt,
+    mb,
+    ml,
+    mr,
+    mx,
+    my,
+  });
 
   const rowStyles: ViewStyle = {
     flexDirection: 'row',

--- a/ui-framework/components/containers/ScrollSection.tsx
+++ b/ui-framework/components/containers/ScrollSection.tsx
@@ -15,11 +15,15 @@ const ScrollSection: React.FC<BaseContainerProps> = ({
   pb,
   pl,
   pr,
+  px,
+  py,
   margin,
   mt,
   mb,
   ml,
   mr,
+  mx,
+  my,
   style,
 }) => {
   const spacing = getSpacingStyles({
@@ -28,11 +32,15 @@ const ScrollSection: React.FC<BaseContainerProps> = ({
     pb,
     pl,
     pr,
+    px,
+    py,
     margin,
     mt,
     mb,
     ml,
     mr,
+    mx,
+    my,
   });
 
   const scrollStyles = {

--- a/ui-framework/utils/getSpacingStyles.ts
+++ b/ui-framework/utils/getSpacingStyles.ts
@@ -24,12 +24,16 @@ export const getSpacingStyles = (props: {
     ...(props.mb && { marginBottom: margin[props.mb] }),
     ...(props.ml && { marginLeft: margin[props.ml] }),
     ...(props.mr && { marginRight: margin[props.mr] }),
+    ...(props.mx && { marginHorizontal: margin[props.mx] }),
+    ...(props.my && { marginVertical: margin[props.my] }),
 
     ...(props.padding && { padding: padding[props.padding] }),
     ...(props.pt && { paddingTop: padding[props.pt] }),
     ...(props.pb && { paddingBottom: padding[props.pb] }),
     ...(props.pl && { paddingLeft: padding[props.pl] }),
     ...(props.pr && { paddingRight: padding[props.pr] }),
+    ...(props.px && { paddingHorizontal: padding[props.px] }),
+    ...(props.py && { paddingVertical: padding[props.py] }),
   };
 
   return styles;


### PR DESCRIPTION
## Summary
- support `px`, `py`, `mx`, `my` in `getSpacingStyles`
- forward new spacing props in `RowView`, `ScrollSection`, and `MainView`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6854210ff0c0832a9e08a95f46513520