### PR TITLE
Add right element support for Input

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -2,7 +2,6 @@ import {
   BoxView,
   Input,
   MainView,
-  RowView,
   ScrollSection,
   StackView,
   textColor,
@@ -86,26 +85,23 @@ export default function SignInScreen() {
               keyboardType="email-address"
               autoCapitalize="none"
             />
-            <RowView style={{ marginBottom: 20, position: "relative" }}>
-              <Input
-                placeholder="Enter password"
-                placeholderTextColor={textColor.secondary}
-                value={password}
-                onChangeText={setPassword}
-                secureTextEntry={!showPassword}
-                autoCapitalize="none"
-              />
-              <TouchableOpacity 
-                onPress={() => setShowPassword(!showPassword)}
-              >
-                <Ionicons 
-                  name={showPassword ? "eye-outline" : "eye-off-outline"}
-                  size={20}
-                  color={textColor.secondary}
-                  style={{ position: "absolute", right: 16, top:16, padding: 4 }}
-                />
-              </TouchableOpacity>
-            </RowView>
+            <Input
+              placeholder="Enter password"
+              placeholderTextColor={textColor.secondary}
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry={!showPassword}
+              autoCapitalize="none"
+              rightElement={
+                <TouchableOpacity onPress={() => setShowPassword(!showPassword)}>
+                  <Ionicons
+                    name={showPassword ? "eye-outline" : "eye-off-outline"}
+                    size={20}
+                    color={textColor.secondary}
+                  />
+                </TouchableOpacity>
+              }
+            />
             
           </StackView>
         </ScrollSection>

--- a/ui-framework/components/form/Input.tsx
+++ b/ui-framework/components/form/Input.tsx
@@ -15,6 +15,7 @@ const Input: React.FC<BaseInputProps> = ({
   bg = "white",
   radius = "md",
   className,
+  rightElement,
   ...rest
 }: BaseInputProps) => {
   const spacing = getSpacingStyles({ padding });
@@ -25,23 +26,30 @@ const Input: React.FC<BaseInputProps> = ({
         <Text style={{ marginBottom: 6, fontWeight: "500" }}>{label}</Text>
       )}
 
-      <TextInput
-        placeholder={placeholder}
-        autoCapitalize="none"
-        secureTextEntry={type === "password"}
-        style={[
-          {
-            width: "100%",
-            borderWidth: 1,
-            borderColor: "#ccc",
-          },
-          { backgroundColor: backgroundColor[bg] },
-          { borderRadius: borderRadius[radius] },
-          spacing,
-          className,
-        ] as StyleProp<TextStyle>}
-        {...rest}
-      />
+      <View style={{ position: "relative" }}>
+        <TextInput
+          placeholder={placeholder}
+          autoCapitalize="none"
+          secureTextEntry={type === "password"}
+          style={[
+            {
+              width: "100%",
+              borderWidth: 1,
+              borderColor: "#ccc",
+            },
+            { backgroundColor: backgroundColor[bg] },
+            { borderRadius: borderRadius[radius] },
+            spacing,
+            className,
+          ] as StyleProp<TextStyle>}
+          {...rest}
+        />
+        {rightElement && (
+          <View style={{ position: "absolute", right: 16, top: 16 }}>
+            {rightElement}
+          </View>
+        )}
+      </View>
     </View>
   );
 };

--- a/ui-framework/components/form/types-forms.ts
+++ b/ui-framework/components/form/types-forms.ts
@@ -25,6 +25,9 @@ export type BaseInputProps = {
   className?: object; // for passing style objects
   required?: boolean;
 
+  /** Optional element to display on the right side of the input */
+  rightElement?: React.ReactNode;
+
   button?: {
     name: string;
     variant: keyof typeof colorVariants;


### PR DESCRIPTION
## Summary
- extend `BaseInputProps` with `rightElement` option
- update `Input` component to render a right element inside the input field
- use the new `rightElement` in the sign-in screen to display the password toggle icon

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68544b0649ac832aa045f36291b9dcc7