### PR TITLE
Fix theme token references

### DIFF
--- a/ui-framework/components/button/buttonVariants.ts
+++ b/ui-framework/components/button/buttonVariants.ts
@@ -8,16 +8,16 @@ export const getButtonStyle = (
   py: keyof typeof padding,
   disabled: boolean = false
 ): { container: ViewStyle; text: TextStyle } => {
-  const { backgroundColor, textColor, borderColor } =
+  const { background, text, borderColor } =
     colorVariants[variant] as {
-      backgroundColor: string;
-      textColor: string;
+      background: string;
+      text: string;
       borderColor?: string;
     };
 
   const styles = {
     container: {
-      backgroundColor: backgroundColor,
+      backgroundColor: background,
       borderRadius: borderRadius[radius] || borderRadius.sm,
       borderWidth: borderColor ? 1 : 0,
       borderColor: borderColor || "transparent",
@@ -28,7 +28,7 @@ export const getButtonStyle = (
       ...(disabled ? state.disabled : {}),
     } as ViewStyle,
     text: {
-      color: textColor,
+      color: text,
       fontWeight: fontWeight.semibold,
       fontSize: 16,
     } as TextStyle,

--- a/ui-framework/components/card/Card.tsx
+++ b/ui-framework/components/card/Card.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { View } from "react-native";
 import { BaseCardProps } from "./types-cards";
 import {
-  backgroundColor,
+  background,
   borderRadius,
   padding,
   margin,
@@ -23,7 +23,7 @@ const Card: React.FC<BaseCardProps> = ({
   style,
 }) => {
   const cardStyles = {
-    backgroundColor: backgroundColor[bg],
+    backgroundColor: background[bg],
     borderRadius: rounded ? borderRadius.xl : 0,
     ...(p ? { padding: padding[p] } : {}),
     ...(px ? { paddingHorizontal: padding[px] } : {}),

--- a/ui-framework/components/card/types-cards.ts
+++ b/ui-framework/components/card/types-cards.ts
@@ -1,10 +1,10 @@
 import { ReactNode } from 'react';
 import { ViewStyle } from 'react-native';
-import { backgroundColor, padding, margin } from '../../theme';
+import { background, padding, margin } from '../../theme';
 
 export interface BaseCardProps {
   children: ReactNode;
-  bg?: keyof typeof backgroundColor;
+  bg?: keyof typeof background;
   padding?: keyof typeof padding;
   px?: keyof typeof padding;
   py?: keyof typeof padding;

--- a/ui-framework/components/containers/BoxView.tsx
+++ b/ui-framework/components/containers/BoxView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View } from "react-native";
 import { BaseContainerProps } from "./types-container";
-import { backgroundColor, borderRadius, shadow } from "../../theme";
+import { background, borderRadius, shadow } from "../../theme";
 import { getSpacingStyles } from "../../utils/getSpacingStyles";
 
 const BoxView: React.FC<BaseContainerProps> = ({
@@ -43,7 +43,7 @@ const BoxView: React.FC<BaseContainerProps> = ({
   });
 
   const boxStyles = {
-    backgroundColor: backgroundColor[bg],
+    backgroundColor: background[bg],
     borderRadius: br ? borderRadius[br] : undefined,
     ...(shadowKey ? shadow[shadowKey] : {}),
     ...spacing,

--- a/ui-framework/components/containers/MainView.tsx
+++ b/ui-framework/components/containers/MainView.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { StyleProp, ViewStyle, SafeAreaView, Platform, StatusBar } from "react-native";
 import { BaseContainerProps } from "./types-container";
 import {
-  backgroundColor,
+  background,
   borderRadius,
   overflow,
   zIndex,
@@ -87,7 +87,7 @@ const MainView: React.FC<BaseContainerProps> = ({
   });
 
   const mainStyles = {
-    backgroundColor: backgroundColor[bg],
+    backgroundColor: background[bg],
     borderRadius: br ? borderRadius[br] : undefined,
     overflow: of ? overflow[of] : undefined,
     zIndex: z ? zIndex[z] : undefined,

--- a/ui-framework/components/containers/RowView.tsx
+++ b/ui-framework/components/containers/RowView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, StyleProp, ViewStyle } from 'react-native';
 import { BaseContainerProps } from './types-container';
-import { backgroundColor, borderRadius, flexGrow, flexWrap, justifyContent, alignItems, shadow } from '../../theme';
+import { background, borderRadius, flexGrow, flexWrap, justifyContent, alignItems, shadow } from '../../theme';
 import { getSpacingStyles } from '../../utils/getSpacingStyles';
 
 const RowView: React.FC<BaseContainerProps> = ({
@@ -48,7 +48,7 @@ const RowView: React.FC<BaseContainerProps> = ({
 
   const rowStyles: ViewStyle = {
     flexDirection: 'row',
-    backgroundColor: backgroundColor[bg],
+    backgroundColor: background[bg],
     borderRadius: br ? borderRadius[br] : undefined,
     flexGrow: fg ? flexGrow[fg] : undefined,
     flexWrap: fw ? flexWrap[fw] : undefined,

--- a/ui-framework/components/containers/ScrollSection.tsx
+++ b/ui-framework/components/containers/ScrollSection.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ScrollView } from "react-native";
 import { BaseContainerProps } from "./types-container";
-import { backgroundColor, borderRadius, overflow, shadow } from "../../theme";
+import { background, borderRadius, overflow, shadow } from "../../theme";
 import { getSpacingStyles } from "../../utils/getSpacingStyles";
 
 const ScrollSection: React.FC<BaseContainerProps> = ({
@@ -44,7 +44,7 @@ const ScrollSection: React.FC<BaseContainerProps> = ({
   });
 
   const scrollStyles = {
-    backgroundColor: backgroundColor[bg],
+    backgroundColor: background[bg],
     borderRadius: br ? borderRadius[br] : undefined,
     overflow: of ? overflow[of] : undefined,
     ...(shadowKey ? shadow[shadowKey] : {}),

--- a/ui-framework/components/containers/StackView.tsx
+++ b/ui-framework/components/containers/StackView.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { View, StyleProp, ViewStyle } from "react-native";
 import { BaseContainerProps } from "./types-container";
 import {
-  backgroundColor,
+  background,
   borderRadius,
   flexGrow,
   justifyContent,
@@ -56,7 +56,7 @@ const StackView: React.FC<BaseContainerProps> = ({
 
   const stackStyles: ViewStyle = {
     flexDirection: "column",
-    backgroundColor: backgroundColor[bg],
+    backgroundColor: background[bg],
     borderRadius: br ? borderRadius[br] : undefined,
     flexGrow: fg ? flexGrow[fg] : undefined,
     justifyContent: justify ? justifyContent[justify] : undefined,

--- a/ui-framework/components/containers/types-container.ts
+++ b/ui-framework/components/containers/types-container.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 import { ViewStyle } from "react-native";
 import {
-  backgroundColor,
+  background,
   borderRadius,
   shadow,
   overflow,
@@ -28,7 +28,7 @@ export interface BaseContainerProps {
   children: ReactNode;
 
   // 🎨 Visual
-  bg?: keyof typeof backgroundColor;
+  bg?: keyof typeof background;
   borderRadius?: keyof typeof borderRadius;
   shadow?: keyof typeof shadow;
   overflow?: keyof typeof overflow;

--- a/ui-framework/components/dropdown/styles-dropdown.ts
+++ b/ui-framework/components/dropdown/styles-dropdown.ts
@@ -2,7 +2,7 @@ import {
   padding,
   fontSize,
   fontWeight,
-  textColor,
+  text,
   borderRadius,
 } from "../../theme";
 import { StyleSheet } from "react-native";
@@ -14,17 +14,17 @@ export const styles = StyleSheet.create({
   label: {
     fontSize: fontSize.sm,
     fontWeight: fontWeight.medium,
-    color: textColor.primary,
+    color: text.primary,
     marginBottom: 4,
   },
   dropdown: {
-    backgroundColor: textColor.accent,
+    backgroundColor: text.accent,
     padding: padding.sm,
     borderRadius: borderRadius.md,
   },
   dropdownText: {
     fontSize: fontSize.base,
-    color: textColor.dark,
+    color: text.dark,
   },
   modalOverlay: {
     flex: 1,
@@ -33,7 +33,7 @@ export const styles = StyleSheet.create({
     paddingHorizontal: padding.md,
   },
   modalContent: {
-    backgroundColor: textColor.white,
+    backgroundColor: text.white,
     borderRadius: borderRadius.lg,
     maxHeight: 300,
     padding: padding.sm,
@@ -43,6 +43,6 @@ export const styles = StyleSheet.create({
   },
   optionText: {
     fontSize: fontSize.base,
-    color: textColor.dark,
+    color: text.dark,
   },
 });

--- a/ui-framework/components/dropdown/types-dropdown.ts
+++ b/ui-framework/components/dropdown/types-dropdown.ts
@@ -4,7 +4,7 @@ import {
   fontSize,
   fontWeight,
   padding,
-  textColor,
+  text,
 } from "../../theme";
 
 export type Option = {

--- a/ui-framework/components/footer/Footer.tsx
+++ b/ui-framework/components/footer/Footer.tsx
@@ -7,8 +7,8 @@ import {
   fontSize,
   fontWeight,
   textAlign,
-  backgroundColor,
-  textColor,
+  background,
+  text,
   overflow,
 } from "../../theme";
 import { BaseFooterProps } from "./types-footer";
@@ -38,7 +38,7 @@ const Footer: React.FC<BaseFooterProps> = ({
     <View
       style={[
         {
-          backgroundColor: backgroundColor[bg],
+          backgroundColor: background[bg],
           padding: padding[paddingKey],
           overflow: overflowKey ? overflow[overflowKey] : undefined,
         },
@@ -74,7 +74,7 @@ const Footer: React.FC<BaseFooterProps> = ({
             style={{
               fontSize: fontSize[fontSizeKey],
               fontWeight: fontWeight[fontWeightKey],
-              color: textColor.primary,
+              color: text.primary,
               textAlign: textAlign[textAlignKey],
               marginBottom: 4,
             } as TextStyle}
@@ -87,7 +87,7 @@ const Footer: React.FC<BaseFooterProps> = ({
           <Text
             style={{
               fontSize: fontSize[fontSizeKey],
-              color: textColor.secondary,
+              color: text.secondary,
               textAlign: textAlign[textAlignKey],
             } as TextStyle}
           >

--- a/ui-framework/components/footer/types-footer.ts
+++ b/ui-framework/components/footer/types-footer.ts
@@ -1,12 +1,12 @@
 import React from 'react';
 import { ViewProps } from 'react-native';
-import { backgroundColor, fontSize, fontWeight, margin, maxWidth, overflow, padding, textAlign } from '../../theme';
+import { background, fontSize, fontWeight, margin, maxWidth, overflow, padding, textAlign } from '../../theme';
 
 export type BaseFooterProps = {
   children?: React.ReactNode;
 
   // 🎨 Visual
-  bg?: keyof typeof backgroundColor;
+  bg?: keyof typeof background;
   overflow?: keyof typeof overflow;
 
   // 📐 Layout

--- a/ui-framework/components/form/Form.tsx
+++ b/ui-framework/components/form/Form.tsx
@@ -5,7 +5,7 @@ import Button from "../button/Button";
 import Input from "./Input";
 import { BaseFormProps, BaseInputProps } from "./types-forms";
 import {
-  backgroundColor,
+  background,
   borderRadius,
   shadow as shadowStyles,
   padding as paddingTokens,
@@ -31,7 +31,7 @@ const Form: React.FC<BaseFormProps> = ({
     padding: padding as keyof typeof paddingTokens,
     margin: margin as keyof typeof marginTokens,
   });
-  const background = { backgroundColor: backgroundColor[bg] };
+  const background = { backgroundColor: background[bg] };
   const border = radius ? { borderRadius: borderRadius["lg"] } : {};
   const elevation = useShadow ? shadowStyles["md"] : {};
 

--- a/ui-framework/components/form/Input.tsx
+++ b/ui-framework/components/form/Input.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { View, Text, TextInput, StyleProp, TextStyle } from "react-native";
 import { getSpacingStyles } from "../../utils/getSpacingStyles";
 import { BaseInputProps } from "./types-forms";
-import { backgroundColor, borderRadius } from "../../theme";
+import { background, borderRadius } from "../../theme";
 
 const Input: React.FC<BaseInputProps> = ({
   id,
@@ -37,7 +37,7 @@ const Input: React.FC<BaseInputProps> = ({
               borderWidth: 1,
               borderColor: "#ccc",
             },
-            { backgroundColor: backgroundColor[bg] },
+            { backgroundColor: background[bg] },
             { borderRadius: borderRadius[radius] },
             spacing,
             className,

--- a/ui-framework/components/form/types-forms.ts
+++ b/ui-framework/components/form/types-forms.ts
@@ -6,7 +6,7 @@ import {
   ViewProps,
 } from "react-native";
 import {
-  backgroundColor,
+  background,
   borderRadius,
   colorVariants,
   margin,
@@ -20,7 +20,7 @@ export type BaseInputProps = {
   type?: "text" | "password";
   placeholder?: string;
   padding?: keyof typeof padding;
-  bg?: keyof typeof backgroundColor;
+  bg?: keyof typeof background;
   radius?: keyof typeof borderRadius;
   className?: object; // for passing style objects
   required?: boolean;
@@ -44,7 +44,7 @@ export type BaseFormProps = {
   title?: string;
   buttonTitle?: string;
   buttonVariant?: keyof typeof colorVariants;
-  bg?: keyof typeof backgroundColor;
+  bg?: keyof typeof background;
   padding?: keyof typeof padding;
   margin?: keyof typeof margin;
   shadow?: boolean;

--- a/ui-framework/components/typography/BodyText.tsx
+++ b/ui-framework/components/typography/BodyText.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text, StyleSheet, StyleProp, TextStyle } from "react-native";
 import { BaseTextProps } from "./types-typography";
-import { fontSize, fontWeight, textAlign, textColor } from "../../theme";
+import { fontSize, fontWeight, textAlign, text } from "../../theme";
 
 const BodyText: React.FC<BaseTextProps> = ({
   children,
@@ -21,7 +21,7 @@ const BodyText: React.FC<BaseTextProps> = ({
         { fontSize: fontSize[size] },
         { fontWeight: fontWeight[weight] },
         // fontTokens[font],
-        { color: textColor[color] },
+        { color: text[color] },
         { textAlign: textAlign[align] },
         italic && styles.italic,
         style,

--- a/ui-framework/components/typography/CaptionText.tsx
+++ b/ui-framework/components/typography/CaptionText.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text, StyleSheet, StyleProp, TextStyle } from "react-native";
 import { BaseTextProps } from "./types-typography";
-import { fontSize, fontWeight, textAlign, textColor } from "../../theme";
+import { fontSize, fontWeight, textAlign, text } from "../../theme";
 
 const CaptionText: React.FC<BaseTextProps> = ({
   children,
@@ -21,7 +21,7 @@ const CaptionText: React.FC<BaseTextProps> = ({
         { fontSize: fontSize[size] },
         { fontWeight: fontWeight[weight] },
         // fontTokens[font],
-        { color: textColor[color] },
+        { color: text[color] },
         { textAlign: textAlign[align] },
         italic && styles.italic,
         style,

--- a/ui-framework/components/typography/Subtitle.tsx
+++ b/ui-framework/components/typography/Subtitle.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text, StyleSheet, StyleProp, TextStyle } from "react-native";
 import { BaseTextProps } from "./types-typography";
-import { fontSize, fontWeight, textAlign, textColor } from "../../theme";
+import { fontSize, fontWeight, textAlign, text } from "../../theme";
 
 const Subtitle: React.FC<BaseTextProps> = ({
   children,
@@ -21,7 +21,7 @@ const Subtitle: React.FC<BaseTextProps> = ({
         { fontSize: fontSize[size] },
         { fontWeight: fontWeight[weight] },
         // fontTokens[font],
-        { color: textColor[color] },
+        { color: text[color] },
         { textAlign: textAlign[align] },
         italic && styles.italic,
         style,

--- a/ui-framework/components/typography/Title.tsx
+++ b/ui-framework/components/typography/Title.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text, StyleSheet, StyleProp, TextStyle } from "react-native";
 import { BaseTextProps } from "./types-typography";
-import { fontSize, fontWeight, textAlign, textColor } from "../../theme";
+import { fontSize, fontWeight, textAlign, text } from "../../theme";
 
 const Title: React.FC<BaseTextProps> = ({
   children,
@@ -21,7 +21,7 @@ const Title: React.FC<BaseTextProps> = ({
         { fontSize: fontSize[size] },
         { fontWeight: fontWeight[weight] },
         // fontTokens[font],
-        { color: textColor[color] },
+        { color: text[color] },
         { textAlign: textAlign[align] },
         italic && styles.italic,
         style,

--- a/ui-framework/components/typography/types-typography.ts
+++ b/ui-framework/components/typography/types-typography.ts
@@ -1,13 +1,13 @@
 import React from "react";
 import { TextProps, StyleProp, TextStyle } from "react-native";
-import { fontSize, fontWeight, textAlign, textColor } from "../../theme";
+import { fontSize, fontWeight, textAlign, text } from "../../theme";
 
 export type BaseTextProps = {
   children: React.ReactNode;
 
   // 🧑🏾 Style Tokens
   align?: keyof typeof textAlign;
-  color?: keyof typeof textColor;
+  color?: keyof typeof text;
   size?: keyof typeof fontSize;
   weight?: keyof typeof fontWeight;
 //   font?: keyof typeof fontTokens;
@@ -18,7 +18,7 @@ export type BaseTextProps = {
 } & TextProps;
 
 export type ListsProps<T> = {
-  color?: keyof typeof textColor;
+  color?: keyof typeof text;
   listDisc?: boolean;
   lists: T[];
   width?: number | string;

--- a/ui-framework/theme/colors.ts
+++ b/ui-framework/theme/colors.ts
@@ -39,50 +39,50 @@ export const borderColor = {
 
 export const colorVariants = {
   primary: {
-    backgroundColor: '#E07A5F',    // Terracotta
-    textColor: '#FFFFFF',
+    background: '#E07A5F',    // Terracotta
+    text: '#FFFFFF',
   },
   secondary: {
-    backgroundColor: '#F4A261',    // Apricot
-    textColor: '#3E2C1C',
+    background: '#F4A261',    // Apricot
+    text: '#3E2C1C',
   },
   accent: {
-    backgroundColor: '#FFF0E0',    // Light peach
-    textColor: '#C1440E',
+    background: '#FFF0E0',    // Light peach
+    text: '#C1440E',
   },
   neutral: {
-    backgroundColor: '#F2F2F2',    // Light grayish
-    textColor: '#58534F',
+    background: '#F2F2F2',    // Light grayish
+    text: '#58534F',
   },
   success: {
-    backgroundColor: '#E8F5E9',
-    textColor: '#2E7D32',
+    background: '#E8F5E9',
+    text: '#2E7D32',
   },
   warning: {
-    backgroundColor: '#FFF3CD',
-    textColor: '#B25C00',
+    background: '#FFF3CD',
+    text: '#B25C00',
   },
   danger: {
-    backgroundColor: '#F8D7DA',
-    textColor: '#C62828',
+    background: '#F8D7DA',
+    text: '#C62828',
   },
   surface: {
-    backgroundColor: '#F9FAFB',
-    textColor: '#2E2A26',
+    background: '#F9FAFB',
+    text: '#2E2A26',
   },
   ghost: {
-    backgroundColor: 'transparent',
-    textColor: '#C1440E',
+    background: 'transparent',
+    text: '#C1440E',
   },
   outlineLight: {
     borderColor: '#C1440E',
-    textColor: '#C1440E',
-    backgroundColor: 'transparent',
+    text: '#C1440E',
+    background: 'transparent',
   },
   outlineDark: {
     borderColor: '#1B1B1B',
-    textColor: '#FFFFFF',
-    backgroundColor: 'transparent',
+    text: '#FFFFFF',
+    background: 'transparent',
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- update `colorVariants` to use `text` and `background`
- change imports and usages from `textColor`/`backgroundColor` to new `text`/`background` tokens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685510bf8518832a980cf3dec1f6b5ea